### PR TITLE
Binary Operators

### DIFF
--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1130,6 +1130,25 @@ namespace jc
 	*/
 	constexpr static bnot_t bnot{};
 
+	/**
+	 * @brief Binary AND operator - "&" function object type
+	*/
+	struct band_t : public operator_tag
+	{
+		template <typename LT, typename RT>
+		constexpr auto operator()(LT&& lhs, RT&& rhs) const
+			noexcept(noexcept(std::declval<LT&&>() & std::declval<RT&&>()))
+			-> decltype(std::declval<LT&&>() & std::declval<RT&&>())
+		{
+			return lhs & rhs;
+		};
+	};
+
+	/**
+	 * @brief Binary AND operator - "&" function object
+	*/
+	constexpr static band_t band{};
+
 };
 
 #pragma endregion BINARY_OPERATORS

--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1149,6 +1149,25 @@ namespace jc
 	*/
 	constexpr static band_t band{};
 
+	/**
+	 * @brief Binary OR operator - "|" function object type
+	*/
+	struct bor_t : public operator_tag
+	{
+		template <typename LT, typename RT>
+		constexpr auto operator()(LT&& lhs, RT&& rhs) const
+			noexcept(noexcept(std::declval<LT&&>() | std::declval<RT&&>()))
+			-> decltype(std::declval<LT&&>() | std::declval<RT&&>())
+		{
+			return lhs | rhs;
+		};
+	};
+
+	/**
+	 * @brief Binary OR operator - "|" function object
+	*/
+	constexpr static bor_t bor{};
+
 };
 
 #pragma endregion BINARY_OPERATORS

--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1106,4 +1106,32 @@ namespace jc
 	constexpr repack_t repack{};
 };
 
+
+#pragma region BINARY_OPERATORS
+
+namespace jc
+{
+	/**
+	 * @brief Binary NOT operator - "~" function object type
+	*/
+	struct bnot_t : public operator_tag
+	{
+		template <typename T>
+		constexpr auto operator()(T&& val) const
+			noexcept(noexcept(~std::declval<T&&>()))
+			-> decltype(~std::declval<T&&>())
+		{
+			return ~val;
+		};
+	};
+
+	/**
+	 * @brief Binary NOT operator - "~" function object
+	*/
+	constexpr static bnot_t bnot{};
+
+};
+
+#pragma endregion BINARY_OPERATORS
+
 #endif

--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1168,6 +1168,25 @@ namespace jc
 	*/
 	constexpr static bor_t bor{};
 
+	/**
+	 * @brief Binary XOR operator - "^" function object type
+	*/
+	struct bxor_t : public operator_tag
+	{
+		template <typename LT, typename RT>
+		constexpr auto operator()(LT&& lhs, RT&& rhs) const
+			noexcept(noexcept(std::declval<LT&&>() ^ std::declval<RT&&>()))
+			-> decltype(std::declval<LT&&>() ^ std::declval<RT&&>())
+		{
+			return lhs ^ rhs;
+		};
+	};
+
+	/**
+	 * @brief Binary XOR operator - "^" function object
+	*/
+	constexpr static bxor_t bxor{};
+
 };
 
 #pragma endregion BINARY_OPERATORS

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -617,6 +617,43 @@ int test_op_band()
 	PASS();
 };
 
+// jc::bor test
+int test_op_bor()
+{
+	NEWTEST();
+
+	constexpr auto operator_v = jc::bor;
+	using value_type = int;
+
+	static_assert(jc::has_operator<decltype(operator_v), value_type, value_type>::value, "missing operator");
+	static_assert(jc::has_operator<decltype(operator_v), value_type>::value, "missing self-applied operator");
+	static_assert(jc::is_invocable_with_count<decltype(operator_v), 2>::value, "failed function probing");
+
+	constexpr value_type operand_a_v = 0b00011011;
+	constexpr value_type operand_b_v = 0b00000111;
+	constexpr value_type expected_v = operand_a_v | operand_b_v;
+
+	const value_type a = operand_a_v;
+	const value_type b = operand_b_v;
+
+	{
+		const value_type q = operator_v(a, b);
+		ASSERT(q == expected_v, "bor operator failed");
+	};
+
+	{
+		const value_type q = b | (a & operator_v);
+		ASSERT(q == expected_v, "bound and piped bor operator failed");
+	};
+
+	{
+		const value_type q = jc::pack(a, b) | operator_v;
+		ASSERT(q == expected_v, "packed and piped bor operator failed");
+	};
+
+	PASS();
+};
+
 
 
 // Runs the tests for the various operators defined by jclib/functional.h
@@ -639,6 +676,7 @@ int test_operators()
 
 	SUBTEST(test_op_bnot);
 	SUBTEST(test_op_band);
+	SUBTEST(test_op_bor);
 
 
 

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -654,6 +654,43 @@ int test_op_bor()
 	PASS();
 };
 
+// jc::bxor test
+int test_op_bxor()
+{
+	NEWTEST();
+
+	constexpr auto operator_v = jc::bxor;
+	using value_type = int;
+
+	static_assert(jc::has_operator<decltype(operator_v), value_type, value_type>::value, "missing operator");
+	static_assert(jc::has_operator<decltype(operator_v), value_type>::value, "missing self-applied operator");
+	static_assert(jc::is_invocable_with_count<decltype(operator_v), 2>::value, "failed function probing");
+
+	constexpr value_type operand_a_v = 0b00011011;
+	constexpr value_type operand_b_v = 0b00000111;
+	constexpr value_type expected_v = operand_a_v ^ operand_b_v;
+
+	const value_type a = operand_a_v;
+	const value_type b = operand_b_v;
+
+	{
+		const value_type q = operator_v(a, b);
+		ASSERT(q == expected_v, "bxor operator failed");
+	};
+
+	{
+		const value_type q = b | (a & operator_v);
+		ASSERT(q == expected_v, "bound and piped bxor operator failed");
+	};
+
+	{
+		const value_type q = jc::pack(a, b) | operator_v;
+		ASSERT(q == expected_v, "packed and piped bxor operator failed");
+	};
+
+	PASS();
+};
+
 
 
 // Runs the tests for the various operators defined by jclib/functional.h
@@ -677,6 +714,7 @@ int test_operators()
 	SUBTEST(test_op_bnot);
 	SUBTEST(test_op_band);
 	SUBTEST(test_op_bor);
+	SUBTEST(test_op_bxor);
 
 
 

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -558,6 +558,7 @@ int test_op_bnot()
 		using value_type = int;
 
 		static_assert(jc::has_operator<decltype(operator_v), value_type>::value, "missing operator");
+		static_assert(jc::is_invocable_with_count<decltype(operator_v), 1>::value, "failed function probing");
 
 		const value_type initial_v = 0b00001111;
 		const value_type new_v = ~initial_v;
@@ -571,6 +572,46 @@ int test_op_bnot()
 
 		i = (i | operator_v);
 		ASSERT(i == initial_v, "piped bnot operator failed");
+
+		i = jc::pack(i) | operator_v;
+		ASSERT(i == new_v, "packed and piped bnot operator failed");
+	};
+
+	PASS();
+};
+
+// jc::band test
+int test_op_band()
+{
+	NEWTEST();
+
+	constexpr auto operator_v = jc::band;
+	using value_type = int;
+
+	static_assert(jc::has_operator<decltype(operator_v), value_type, value_type>::value, "missing operator");
+	static_assert(jc::has_operator<decltype(operator_v), value_type>::value, "missing self-applied operator");
+	static_assert(jc::is_invocable_with_count<decltype(operator_v), 2>::value, "failed function probing");
+
+	constexpr value_type operand_a_v = 0b00011011;
+	constexpr value_type operand_b_v = 0b00000111;
+	constexpr value_type expected_v = operand_a_v & operand_b_v;
+
+	const value_type a = operand_a_v;
+	const value_type b = operand_b_v;
+
+	{
+		const value_type q = operator_v(a, b);
+		ASSERT(q == expected_v, "band operator failed");
+	};
+
+	{
+		const value_type q = b | (a & operator_v);
+		ASSERT(q == expected_v, "bound and piped band operator failed");
+	};
+
+	{
+		const value_type q = jc::pack(a, b) | operator_v;
+		ASSERT(q == expected_v, "packed and piped band operator failed");
 	};
 
 	PASS();
@@ -597,6 +638,7 @@ int test_operators()
 	// Test binary arithmetic operators
 
 	SUBTEST(test_op_bnot);
+	SUBTEST(test_op_band);
 
 
 

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -547,6 +547,37 @@ int test_op_modulo()
 
 
 
+// jc::bnot test
+int test_op_bnot()
+{
+	NEWTEST();
+	constexpr auto operator_v = jc::bnot;
+
+	// Test operator
+	{
+		using value_type = int;
+
+		static_assert(jc::has_operator<decltype(operator_v), value_type>::value, "missing operator");
+
+		const value_type initial_v = 0b00001111;
+		const value_type new_v = ~initial_v;
+
+		value_type i = initial_v;
+
+		ASSERT(i == initial_v, "invalid bnot test condition");
+
+		i = operator_v(i);
+		ASSERT(i == new_v, "bnot operator failed");
+
+		i = (i | operator_v);
+		ASSERT(i == initial_v, "piped bnot operator failed");
+	};
+
+	PASS();
+};
+
+
+
 // Runs the tests for the various operators defined by jclib/functional.h
 int test_operators()
 {
@@ -565,6 +596,7 @@ int test_operators()
 
 	// Test binary arithmetic operators
 
+	SUBTEST(test_op_bnot);
 
 
 


### PR DESCRIPTION
Added various binary arithmetic operators and simple tests for them.

`jc::bnot_t`, `jc::bnot` - binary NOT operator (~a)
`jc::bor_t`, `jc::bor` - binary OR operator (a | b)
`jc::band_t`, `jc::band` - binary AND operator (a & b)
`jc::bxor_t`, `jc::bxor` - binary XOR operator (a ^ b)

As of right now, I will not add the NOT version of these (ie. NAND) as they can be easily constructed like so:
```
constexpr auto bnand = jc::band | jc::bnot;
```