### PR TITLE
Access operators

### DIFF
--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -581,27 +581,6 @@ namespace jc
 	constexpr static disjunct_t disjunct{};
 
 
-
-	/**
-	 * @brief Unary dereference "*" function object type (ie. dereference(int*) -> int&)
-	*/
-	struct dereference_t : public operator_tag
-	{
-	public:
-		template <typename T>
-		constexpr auto operator()(T&& _value) const noexcept ->
-			decltype(*std::declval<T&&>())
-		{
-			return *_value;
-		};
-	};
-
-	/**
-	 * @brief Unary dereference "*" function object (ie. dereference(int*) -> int&)
-	*/
-	constexpr static dereference_t dereference{};
-
-
 	
 	/**
 	 * @brief Binary modulus "%" function object type (ie. modulo(3, 2) -> 1)
@@ -1190,5 +1169,40 @@ namespace jc
 };
 
 #pragma endregion BINARY_OPERATORS
+
+
+
+/*
+	Member access operators and other value access operators
+*/
+#pragma region ACCESSOR_OPERATORS
+
+namespace jc
+{
+	/**
+	 * @brief Unary dereference operator - "*" function object type (ie. dereference(int*) -> int&)
+	*/
+	struct dereference_t : public operator_tag
+	{
+	public:
+		template <typename T>
+		constexpr auto operator()(T&& _value) const noexcept ->
+			decltype(*std::declval<T&&>())
+		{
+			return *_value;
+		};
+	};
+
+	/**
+	 * @brief Unary dereference operator - "*" function object type (ie. dereference(int*) -> int&)
+	*/
+	constexpr static dereference_t dereference{};
+
+
+
+};
+
+#pragma endregion ACCESSOR_OPERATORS
+
 
 #endif

--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1200,6 +1200,31 @@ namespace jc
 
 
 
+	/**
+	 * @brief Unary address_of operator - "&" function object type (ie. address_of(int) -> int*)
+	*/
+	struct address_of_t : public operator_tag
+	{
+		template <typename T>
+		constexpr auto operator()(T&& val) const
+			noexcept(noexcept(&std::declval<T&&>()))
+			-> decltype(&std::declval<T&&>())
+		{
+			return &val;
+		};
+		
+		// Wildcard overload for function probing
+		constexpr auto operator()(wildcard w) const
+		{
+			return w;
+		};
+	};
+
+	/**
+	 * @brief Unary address_of operator - "&" function object (ie. address_of(int) -> int*)
+	*/
+	constexpr static address_of_t address_of{};
+
 };
 
 #pragma endregion ACCESSOR_OPERATORS

--- a/include/jclib/ranges.h
+++ b/include/jclib/ranges.h
@@ -829,7 +829,7 @@ namespace jc
 					return this->end_;
 				};
 
-				constexpr filter_view_impl(RangeT& _range, jc::remove_cvref_t<OpT>&& _op) :
+				constexpr filter_view_impl(RangeT& _range, jc::remove_cvref_t<OpT> _op) :
 					filter_{ std::move(_op) },
 					begin_{ ranges::begin(_range), ranges::end(_range),  this->filter_ },
 					end_{ ranges::end(_range), ranges::end(_range), this->filter_ }
@@ -870,6 +870,13 @@ namespace jc
 					ranges::filter_view<remove_reference_t<RangeT>, OpT>
 				{
 					return ranges::filter_view<remove_reference_t<RangeT>, OpT>{ _range, std::move(_filter.op) };
+				};
+
+				template <typename RangeT>
+				constexpr auto operator()(RangeT&& _range) const
+					-> ranges::filter_view<remove_reference_t<RangeT>, OpT>
+				{
+					return ranges::filter_view<remove_reference_t<RangeT>, OpT>{ _range, this->op };
 				};
 
 				constexpr filter_impl(OpT&& _op) noexcept :

--- a/include/jclib/type_traits.h
+++ b/include/jclib/type_traits.h
@@ -646,6 +646,10 @@ namespace jc
 		{};
 	};
 
+	/**
+	 * @brief Wildcard type used for function trait probing (ie. jc::is_invocable_with_count)
+	*/
+	using wildcard = jc::impl::wildcard;
 
 
 	/**

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -390,20 +390,29 @@ int test_op_dereference()
 		using value_type = int;
 
 		static_assert(jc::has_operator<decltype(operator_v), value_type*>::value, "missing operator");
+		static_assert(jc::is_invocable_with_count<decltype(operator_v), 1>::value, "failed function probing");
+		
+		value_type n = 125;
+		value_type* nptr = &n;
 
-		const value_type initial_v = 0;
-		const value_type new_v = 2;
+		// Test invocation
+		{
+			auto q = operator_v(nptr);
+			ASSERT(q == n, "dereference operator failed");
+		};
+		
+		// Test piped invocation
+		{
+			auto q = nptr | operator_v;
+			ASSERT(q == n, "piped dereference operator failed");
+		};
 
-		value_type i = initial_v;
-		value_type* iptr = &i;
+		// Test packed piped invocation
+		{
+			auto q = jc::pack(nptr) | operator_v;
+			ASSERT(q == n, "packed and piped dereference operator failed");
+		};
 
-		ASSERT(i == initial_v, "invalid dereference test condition");
-
-		jc::dereference(iptr) = new_v;
-		ASSERT(i == new_v, "dereference operator failed");
-
-		(iptr | jc::dereference) = initial_v;
-		ASSERT(i == initial_v, "piped dereference operator failed");
 	};
 
 	// Test with const value pointer
@@ -412,16 +421,26 @@ int test_op_dereference()
 
 		static_assert(jc::has_operator<decltype(operator_v), const value_type*>::value, "missing operator");
 
-		const value_type initial_v = 0;
-		const value_type new_v = 2;
+		value_type n = 125;
+		value_type* nptr = &n;
 
-		value_type i = initial_v;
-		value_type* iptr = &i;
+		// Test invocation
+		{
+			auto q = operator_v(nptr);
+			ASSERT(q == n, "dereference operator with const value type failed");
+		};
 
-		ASSERT(i == initial_v, "invalid dereference test condition");
+		// Test piped invocation
+		{
+			auto q = nptr | operator_v;
+			ASSERT(q == n, "piped dereference operator with const value type failed");
+		};
 
-		auto& iref = jc::dereference(iptr);
-		ASSERT(&i == &iref, "dereference operator failed on const value");
+		// Test packed piped invocation
+		{
+			auto q = jc::pack(nptr) | operator_v;
+			ASSERT(q == n, "packed and piped dereference operator with const value type failed");
+		};
 	};
 
 	PASS();

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -703,8 +703,8 @@ int test_op_bxor()
 	};
 
 	{
-		const value_type q = jc::pack(a, b) | operator_v;
-		ASSERT(q == expected_v, "packed and piped bxor operator failed");
+	const value_type q = jc::pack(a, b) | operator_v;
+	ASSERT(q == expected_v, "packed and piped bxor operator failed");
 	};
 
 	PASS();
@@ -785,6 +785,62 @@ int test_op_address_of()
 };
 
 
+int test_op_member()
+{
+	NEWTEST();
+
+	// Testing operator value alias
+	constexpr auto operator_v = jc::member;
+
+	// Test arguement binding
+	{
+		using value_type = std::pair<int, int>;
+		
+		constexpr auto first_fn = operator_v & (&value_type::first);
+		constexpr auto second_fn = operator_v & (&value_type::second);
+
+		value_type v{ 1, 12 };
+		auto& first = v.first;
+		auto& second = v.second;
+
+		// Test invocation access
+		{
+			auto& q = first_fn(v);
+			ASSERT(q == first, "bad member access operator (first)");
+		};
+		{
+			auto& q = second_fn(v);
+			ASSERT(q == second, "bad member access operator (second)");
+		};
+
+		// Test piped access
+		{
+			auto& q = v | first_fn;
+			ASSERT(q == first, "bad piped member access operator (first)");
+		};
+		{
+			auto& q = v | second_fn;
+			ASSERT(q == second, "bad piped member access operator (second)");
+		};
+
+#if JCLIB_VERSION_MAJOR >= 0 && JCLIB_VERSION_MINOR >= 2 && JCLIB_VERSION_PATCH >= 3
+		// Test packed piped access
+		{
+			auto q = jc::pack(v) | first_fn;
+			ASSERT(q == first, "bad piped member access operator (first)");
+		};
+		{
+			auto& q = jc::pack(v) | second_fn;
+			ASSERT(q == second, "bad piped member access operator (second)");
+		};
+#endif
+	};
+
+	PASS();
+};
+
+
+
 // Runs the tests for the various operators defined by jclib/functional.h
 int test_operators()
 {
@@ -823,7 +879,7 @@ int test_operators()
 
 	SUBTEST(test_op_dereference);
 	SUBTEST(test_op_address_of);
-
+	SUBTEST(test_op_member);
 	
 
 	PASS();
@@ -924,8 +980,13 @@ struct Foo
 
 constexpr auto add(int a, int b) { return a + b; };
 
+#include <jclib/ranges.h>
+#include <jclib/algorithm.h>
+
 int main()
 {
+	
+
 	SUBTEST(test_operators);
 	SUBTEST(test_piping);
 

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -712,6 +712,79 @@ int test_op_bxor()
 
 
 
+// jc::address_of test
+int test_op_address_of()
+{
+	NEWTEST();
+
+	constexpr auto operator_v = jc::address_of;
+
+	// Test with non-const value
+	{
+		using value_type = int;
+
+		static_assert(jc::has_operator<decltype(operator_v), value_type&>::value, "missing operator");
+		static_assert(jc::is_invocable_with_count<decltype(operator_v), 1>::value, "failed function probing");
+
+		value_type n = 125;
+		value_type* nptr = &n;
+
+		// Test invocation
+		{
+			auto q = operator_v(n);
+			ASSERT(q == nptr, "address_of operator failed");
+		};
+
+		// Test piped invocation
+		{
+			auto q = n | operator_v;
+			ASSERT(q == nptr, "piped address_of operator failed");
+		};
+
+#if JCLIB_VERSION_MAJOR >= 0 && JCLIB_VERSION_MINOR >= 2 && JCLIB_VERSION_PATCH >= 3
+		// Test packed piped invocation
+		{
+			auto q = jc::pack(n) | operator_v;
+			ASSERT(q == nptr, "packed and piped address_of operator failed");
+		};
+#endif
+
+	};
+
+	// Test with const value pointer
+	{
+		using value_type = const int;
+
+		static_assert(jc::has_operator<decltype(operator_v), value_type&>::value, "missing operator");
+
+		value_type n = 125;
+		value_type* nptr = &n;
+
+		// Test invocation
+		{
+			auto q = operator_v(n);
+			ASSERT(q == nptr, "address_of operator with const value type failed");
+		};
+
+		// Test piped invocation
+		{
+			auto q = n | operator_v;
+			ASSERT(q == nptr, "piped address_of operator with const value type failed");
+		};
+
+#if JCLIB_VERSION_MAJOR >= 0 && JCLIB_VERSION_MINOR >= 2 && JCLIB_VERSION_PATCH >= 3
+		// Test packed piped invocation
+		{
+			auto q = jc::pack(n) | operator_v;
+			ASSERT(q == nptr, "packed and piped address_of operator with const value type failed");
+		};
+#endif
+	};
+
+	PASS();
+};
+
+
 // Runs the tests for the various operators defined by jclib/functional.h
 int test_operators()
 {
@@ -749,7 +822,7 @@ int test_operators()
 	// Test other operators
 
 	SUBTEST(test_op_dereference);
-
+	SUBTEST(test_op_address_of);
 
 	
 

--- a/tests/functional/test.cpp
+++ b/tests/functional/test.cpp
@@ -784,7 +784,7 @@ int test_op_address_of()
 	PASS();
 };
 
-
+// jc::member test
 int test_op_member()
 {
 	NEWTEST();
@@ -980,13 +980,10 @@ struct Foo
 
 constexpr auto add(int a, int b) { return a + b; };
 
-#include <jclib/ranges.h>
-#include <jclib/algorithm.h>
+
 
 int main()
 {
-	
-
 	SUBTEST(test_operators);
 	SUBTEST(test_piping);
 


### PR DESCRIPTION
`jc::member_t`, `jc::member` - Allows member access within the functional system
`jc::address_of_t`, `jc::address_of` - Gets a pointer to an lvalue