### PR TITLE
Initial constexpr algorithm backporting

### DIFF
--- a/config/in/algorithm.cmake
+++ b/config/in/algorithm.cmake
@@ -1,0 +1,10 @@
+#
+#	Algorithm configuration support CMake
+#
+
+# Only relevent when compiling for C++14/17
+option(JCLIB_CONSTEXPR_ALGORIHMS "Enables custom constexpr versions of std algorithms, this may affect performance" ON)
+
+
+
+ADD_CONFIG_FILE("algorithm.in.h")

--- a/config/in/algorithm.cmake
+++ b/config/in/algorithm.cmake
@@ -3,7 +3,7 @@
 #
 
 # Only relevent when compiling for C++14/17
-option(JCLIB_CONSTEXPR_ALGORIHMS "Enables custom constexpr versions of std algorithms, this may affect performance" ON)
+option(JCLIB_CONSTEXPR_ALGORITHMS "Enables custom constexpr versions of std algorithms, this may affect performance" ON)
 
 
 

--- a/config/in/algorithm.in.h
+++ b/config/in/algorithm.in.h
@@ -1,0 +1,31 @@
+#pragma once
+#ifndef JCLIB_CONFIG_ALGORITHM_H
+#define JCLIB_CONFIG_ALGORITHM_H
+
+/*
+	Copyright 2021 Jonathan Cline
+	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+	(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
+	so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+	WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+	COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/**
+ *	@brief Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
+*/
+#cmakedefine JCLIB_CONSTEXPR_ALGORIHMS
+
+#ifdef JCLIB_CONSTEXPR_ALGORIHMS
+	// Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
+	#define JCLIB_CONSTEXPR_ALGORIHMS_V true
+#else
+	// Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
+	#define JCLIB_CONSTEXPR_ALGORIHMS_V false
+#endif
+
+#endif

--- a/config/in/algorithm.in.h
+++ b/config/in/algorithm.in.h
@@ -18,14 +18,14 @@
 /**
  *	@brief Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
 */
-#cmakedefine JCLIB_CONSTEXPR_ALGORIHMS
+#cmakedefine JCLIB_CONSTEXPR_ALGORITHMS
 
-#ifdef JCLIB_CONSTEXPR_ALGORIHMS
+#ifdef JCLIB_CONSTEXPR_ALGORITHMS
 	// Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
-	#define JCLIB_CONSTEXPR_ALGORIHMS_V true
+	#define JCLIB_CONSTEXPR_ALGORITHMS_V true
 #else
 	// Enables custom std algorithm implementations for backporting constexpr support when using C++14/17
-	#define JCLIB_CONSTEXPR_ALGORIHMS_V false
+	#define JCLIB_CONSTEXPR_ALGORITHMS_V false
 #endif
 
 #endif

--- a/config/in/version.in.h
+++ b/config/in/version.in.h
@@ -2,6 +2,19 @@
 #ifndef JCLIB_CONFIG_VERSION_H
 #define JCLIB_CONFIG_VERSION_H
 
+/*
+	Copyright 2021 Jonathan Cline
+	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+	(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
+	so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+	WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+	COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #define JCLIB_VERSION_MAJOR ${JCLIB_VERSION_MAJOR}
 #define JCLIB_VERSION_MINOR ${JCLIB_VERSION_MINOR}
 #define JCLIB_VERSION_PATCH	${JCLIB_VERSION_PATCH}

--- a/include/jclib/algorithm.h
+++ b/include/jclib/algorithm.h
@@ -30,14 +30,43 @@
 #include <jclib/config/algorithm.h>
 
 #include <algorithm>
+#include <numeric>
 
 #define _JCLIB_ALGORITHM_
 
+
+/*
+	 Determine if the standard library has constexpr algorithms and add a macro for ease of implementation custom backports
+*/
+#if JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS_V
+
+	// Use standard library algorithms
+	#define JCLIB_ALGORITHM_H_USE_STD_ALGORITHMS
+	
+	// jclib/algorithm.h specific constexpr macro
+	#define JCLIB_ALGORITHM_H_CONSTEXPR constexpr
+
+#elif JCLIB_CONSTEXPR_ALGORITHMS_V
+
+	// Use custom algorithm backports
+	#define JCLIB_ALGORITHM_H_USE_CUSTOM_ALGORITHMS
+	
+	// jclib/algorithm.h specific constexpr macro
+	#define JCLIB_ALGORITHM_H_CONSTEXPR constexpr
+
+#else
+
+	// Use standard library algorithms
+	#define JCLIB_ALGORITHM_H_USE_STD_ALGORITHMS
+	
+	// jclib/algorithm.h specific constexpr macro
+	#define JCLIB_ALGORITHM_H_CONSTEXPR
+
+#endif
+
+
 namespace jc
 {
-
-	
-
 
 
 	/**

--- a/include/jclib/algorithm.h
+++ b/include/jclib/algorithm.h
@@ -17,18 +17,29 @@
 
 /*
 	Provides range based std-algorithms using jclib ranges and provides a few other small algorithms
+
+	Constexpr versions of standard library algorithms will also be made available for C++14/17 if the
+	relevant CMake option is set.
 */
 
 #include <jclib/ranges.h>
 #include <jclib/functional.h>
 #include <jclib/feature.h>
 
-#define _JCLIB_ALGORITHM_
+// Algorithm config file
+#include <jclib/config/algorithm.h>
 
 #include <algorithm>
 
+#define _JCLIB_ALGORITHM_
+
 namespace jc
 {
+
+	
+
+
+
 	/**
 	 * @brief Returns an iterator the value specified if it exists
 	 * @tparam RangeT Range object type to look in

--- a/include/jclib/config.h
+++ b/include/jclib/config.h
@@ -146,7 +146,7 @@ namespace jc
 
 // Convenience macro for c++20 requires clauses
 #ifndef JCLIB_REQUIRES
-#ifdef __cpp_concepts
+#if JCLIB_FEATURE_CONCEPTS_V
 #define JCLIB_REQUIRES(x) requires (x)
 #else
 #define JCLIB_REQUIRES(x)

--- a/include/jclib/config.h
+++ b/include/jclib/config.h
@@ -17,6 +17,9 @@
 
 #include <jclib/config/version.h>
 
+// Include the C++ feature testing header
+#include <jclib/feature.h>
+
 #define _JCLIB_CONFIG_
 
 #ifdef __cpp_constexpr
@@ -222,7 +225,16 @@ namespace jc
 	#define JCLIB_DEBUG_V false
 #endif
 
-
+// Make return type sfinae enable_if concepts switch
+#if JCLIB_FEATURE_CONCEPTS_V
+	// Uses enable_if_t if concepts are not available - for use with function return type enable_if SFINAE
+	// This is a bit of a cryptic macro so avoid it unless you know what it is doing
+	#define JCLIB_RET_SFINAE_CXSWITCH(retType, ...) retType
+#else
+	// Uses enable_if_t if concepts are not available - for use with function return type enable_if SFINAE
+	// This is a bit of a cryptic macro so avoid it unless you know what it is doing
+	#define JCLIB_RET_SFINAE_CXSWITCH(retType, ...) ::jc::enable_if_t<__VA_ARGS__, retType>
+#endif
 
 namespace jc
 {

--- a/include/jclib/feature.h
+++ b/include/jclib/feature.h
@@ -179,22 +179,22 @@
 	Test for __cpp_lib_constexpr_algorithms
 */
 
-#define JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS 201806L
-#if defined(__cpp_lib_constexpr_algorithms) && JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS != __cpp_lib_constexpr_algorithms
+#define JCLIB_FEATURE_VALUE_CPP_CONSTEXPR_ALGORITHMS 201806L
+#if defined(__cpp_lib_constexpr_algorithms) && JCLIB_FEATURE_VALUE_CPP_CONSTEXPR_ALGORITHMS != __cpp_lib_constexpr_algorithms
 	#error "Feature testing value mismatch"
 #endif
-#if JCLIB_CPP >= JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS || __cpp_lib_constexpr_algorithms >= JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS
-	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
+#if JCLIB_CPP >= JCLIB_FEATURE_VALUE_CPP_CONSTEXPR_ALGORITHMS || __cpp_lib_constexpr_algorithms >= JCLIB_FEATURE_VALUE_CPP_CONSTEXPR_ALGORITHMS
+	#define JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS
 #else
-	#ifdef JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
+	#ifdef JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS
 		#error "Feature testing macro was defined when it shouldn't be"
 	#endif
 #endif
 
-#ifdef JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
-	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS_V true
+#ifdef JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS
+	#define JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS_V true
 #else
-	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS_V false
+	#define JCLIB_FEATURE_CPP_CONSTEXPR_ALGORITHMS_V false
 #endif
 
 

--- a/include/jclib/feature.h
+++ b/include/jclib/feature.h
@@ -175,5 +175,27 @@
 #endif
 
 
+/*
+	Test for __cpp_lib_constexpr_algorithms
+*/
+
+#define JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS 201806L
+#if defined(__cpp_lib_constexpr_algorithms) && JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS != __cpp_lib_constexpr_algorithms
+	#error "Feature testing value mismatch"
+#endif
+#if JCLIB_CPP >= JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS || __cpp_lib_constexpr_algorithms >= JCLIB_FEATURE_VALUE_CONSTEXPR_ALGORITHMS
+	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
+#else
+	#ifdef JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
+		#error "Feature testing macro was defined when it shouldn't be"
+	#endif
+#endif
+
+#ifdef JCLIB_FEATURE_CONSTEXPR_ALGORITHMS
+	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS_V true
+#else
+	#define JCLIB_FEATURE_CONSTEXPR_ALGORITHMS_V false
+#endif
+
 
 #endif

--- a/tests/algorithm/test.cpp
+++ b/tests/algorithm/test.cpp
@@ -261,8 +261,171 @@ int test_contains_if()
 	PASS();
 };
 
+#include <array>
 
 
+template <typename T>
+constexpr auto summate(const T& _range)
+{
+	auto _sum = jc::ranges::value_t<T>{};
+	for (auto& v : _range)
+	{
+		_sum += v;
+	};
+	return _sum;
+};
+
+
+// jc::accumulate test
+int test_accumulate()
+{
+	NEWTEST();
+
+	// Testing input ranges
+
+	const int c_array_const[4]{ 0, 1, 2, 3 };
+	int c_array[4]{ 0, 1, 2, 3 };
+
+	const std::array<int, 4> cpp_array_const{ 0, 1, 2, 3 };
+	std::array<int, 4> cpp_array{ cpp_array_const };
+
+	// Check preconditions
+	const auto sum = summate(cpp_array_const);
+
+	ASSERT(summate(c_array) == sum, "invalid test preconditions on c_array");
+	ASSERT(summate(c_array_const) == sum, "invalid test preconditions on c_array_const");
+	ASSERT(summate(cpp_array) == sum, "invalid test preconditions on cpp_array");
+	ASSERT(summate(cpp_array_const) == sum, "invalid test preconditions on cpp_array_const");
+
+	const int _init = 0;
+	const auto& _accumFn = jc::plus;
+
+	// Test C-Array
+	{
+		auto& _data = c_array;
+#define _IGNORE_TEST_RANGE_NAME_HERE "c_array"
+
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn, _init);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn, _init);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default init value");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default init value");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data));
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default op function value");
+		};
+		{
+			auto _result = jc::accumulate(_data);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default op function value");
+		};
+	};
+
+	// Test Const C-Array
+	{
+		auto& _data = c_array_const;
+#define _IGNORE_TEST_RANGE_NAME_HERE "c_array_const"
+
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn, _init);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn, _init);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default init value");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default init value");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data));
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default op function value");
+		};
+		{
+			auto _result = jc::accumulate(_data);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default op function value");
+		};
+	};
+
+	// Test C++ Array
+	{
+		auto& _data = cpp_array;
+#define _IGNORE_TEST_RANGE_NAME_HERE "cpp_array"
+
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn, _init);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn, _init);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default init value");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default init value");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data));
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default op function value");
+		};
+		{
+			auto _result = jc::accumulate(_data);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default op function value");
+		};
+	};
+
+	// Test Const C++ Array
+	{
+		auto& _data = cpp_array_const;
+#define _IGNORE_TEST_RANGE_NAME_HERE "cpp_array_const"
+
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn, _init);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn, _init);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data), _accumFn);
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default init value");
+		};
+		{
+			auto _result = jc::accumulate(_data, _accumFn);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default init value");
+		};
+		{
+			const auto _result = jc::accumulate(jc::begin(_data), jc::end(_data));
+			ASSERT(_result == sum, "accumulate result on " _IGNORE_TEST_RANGE_NAME_HERE " mismatch - bad default op function value");
+		};
+		{
+			auto _result = jc::accumulate(_data);
+			ASSERT(_result == sum, "range based accumulate on " _IGNORE_TEST_RANGE_NAME_HERE " result mismatch - bad default op function value");
+		};
+	};
+
+	PASS();
+};
 
 
 
@@ -279,6 +442,7 @@ int main()
 	SUBTEST(test_contains);
 	SUBTEST(test_contains_if);
 
+	SUBTEST(test_accumulate);
 
 	PASS();
 };


### PR DESCRIPTION
I have no more energy left to implement these things, but I've laid out the groundwork for future back porting of `constexpr` standard library algorithms. The only one I've implemented is `jc::accumulate` which features an iterator based version and a range based version.

Use the CMake option `JCLIB_CONSTEXPR_ALGORITHMS` to enable/disable custom `constexpr` algorithms. Note that if you are compiling for C++20 and the standard library has `constexpr` algorithms available, these will be used even if `JCLIB_CONSTEXPR_ALGORITHMS` is enabled.