### PR TITLE
Derived Guard Type Support

### DIFF
--- a/tests/guard/derived.cmake
+++ b/tests/guard/derived.cmake
@@ -1,0 +1,3 @@
+# guard-derived Test Driver
+
+JCLIB_ADD_TEST("guard-derived" "${CMAKE_CURRENT_LIST_DIR}/derived.cpp")

--- a/tests/guard/derived.cpp
+++ b/tests/guard/derived.cpp
@@ -1,0 +1,58 @@
+#include <jclib-test.hpp>
+
+#include <jclib/guard.h>
+
+
+
+
+
+struct GuardedObject
+{
+	void reset() {};
+	bool value = false;
+};
+
+
+struct Guard : public jc::guard<GuardedObject>
+{
+	static_assert(jc::is_same<guarded_type, GuardedObject>::value, "");
+
+	bool& value()
+	{
+		return this->get_guarded().value;
+	};
+	const bool& value() const
+	{
+		return this->get_guarded().value;
+	};
+
+	using jc::guard<GuardedObject>::guard;
+};
+
+
+// Test derived guard access behavior
+int subtest_derived()
+{
+	NEWTEST();
+
+	Guard _guard{ GuardedObject{  } };
+
+	const auto _initial = _guard.value();
+	_guard.value() = !_guard.value();
+
+	const auto _postval = _guard.value();
+
+	ASSERT(_initial != _postval, "derived guard accessor did not return a reference");
+
+	PASS();
+};
+
+
+
+
+int main()
+{
+	NEWTEST();
+	SUBTEST(subtest_derived);
+	PASS();
+};


### PR DESCRIPTION
Changed `jc::guard` to allow types derived types to access the underlying guarded object.