### PR TITLE
Added noexcept helper macro for jclib's exceptions

### DIFF
--- a/include/jclib/config.h
+++ b/include/jclib/config.h
@@ -204,6 +204,18 @@ namespace jc
 #endif
 
 
+// Define the noexcept helper only used if exceptions are enabled
+
+#if JCLIB_EXCEPTIONS_V
+	// Same as noexcept( cond ) but only evaluates the condition if jclib has exceptions enabled
+	#define JCLIB_NOEXCEPT_IF(cond) noexcept( cond )
+#else
+	// Same as noexcept( cond ) but only evaluates the condition if jclib has exceptions enabled
+	#define JCLIB_NOEXECPT_IF(cond) noexcept(true)
+#endif
+
+// Same as noexcept(false) if jclib has exceptions enabled, otherwise is just regular noexcept
+#define JCLIB_NOEXCEPT JCLIB_NOEXCEPT_IF(false)
 
 
 


### PR DESCRIPTION
Added a macro named `JCLIB_NOEXCEPT_IF` and another named `JCLIB_NOEXCEPT` that behave like the `noexcept` keyword but will be overriden as true if jclib's exceptions are disabled.