### PR TITLE
Fix null compare for T*

### DIFF
--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -110,14 +110,20 @@ namespace jc
 	template <typename T>
 	struct null_ftor;
 
+	/**
+	 * @brief Define pointers as nullable types
+	 * @tparam T Type being pointed to.
+	*/
 	template <typename T>
 	struct null_ftor<T*>
 	{
-		constexpr static T* make_null() noexcept
+		using type = T*;
+
+		constexpr static type make_null() noexcept
 		{
 			return nullptr;
 		};
-		constexpr static bool is_null(T* const& _value) noexcept
+		constexpr static bool is_null(const type& _value) noexcept
 		{
 			return _value == nullptr;
 		};

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -24,6 +24,9 @@ int subtest_pointer_type()
 	{
 		ASSERT((p != jc::null) == true, "Valid pointer was considered null!");
 		ASSERT((p == jc::null) == false, "Valid pointer was considered null!");
+		ASSERT((&a != jc::null) == true, "Valid pointer temporary was considered null!");
+		ASSERT((&a != jc::null) == true, "Valid pointer temporary was considered null!");
+
 		ASSERT((np == jc::null) == true, "Null pointer was NOT considered null by jc::null!");
 		ASSERT((np != jc::null) == false, "Null pointer was NOT considered null by jc::null!");
 


### PR DESCRIPTION
Fixed issue where `non-const T*` was not considered null comparable.

This was causing me problems.