### PR TITLE
Added the most typical shorthand for the member operator.

### DIFF
--- a/include/jclib/functional.h
+++ b/include/jclib/functional.h
@@ -1253,7 +1253,13 @@ namespace jc
 			return _obj.*_member;
 		};
 
-
+		template <typename ClassT, typename VarT>
+		constexpr auto operator()(VarT ClassT::* _member) const
+		{
+			// TODO : Upgrade this to use a dedicated struct return rather than
+			// abusing argument binding like this
+			return (*this) & _member;
+		};
 
 		// Wildcard overloads for function probing
 		constexpr auto operator()(wildcard w) const


### PR DESCRIPTION
Allows `jc::member(&Foo::name)` as well as what was
already allowed `jc::member & &Foo::name`.

This makes usage a bit more typical and in line with the rest of the operators.