### PR TITLE
No copy/move types

### DIFF
--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -288,6 +288,20 @@ namespace jc
 		constexpr no_move_construct(no_move_construct&&) noexcept = delete;
 		constexpr no_move_construct& operator=(no_move_construct&&) noexcept = default;
 	};
+
+	/**
+	 * @brief Type that has its move assignment operator deleted.
+	 *
+	 * Inherit from this to easily delete the move assignment operator.
+	*/
+	struct no_move_assign
+	{
+		constexpr no_move_assign() noexcept = default;
+		constexpr no_move_assign(const no_move_assign&) noexcept = default;
+		constexpr no_move_assign& operator=(const no_move_assign&) noexcept = default;
+		constexpr no_move_assign(no_move_assign&&) noexcept = default;
+		constexpr no_move_assign& operator=(no_move_assign&&) noexcept = delete;
+	};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -267,6 +267,13 @@ namespace jc
 		constexpr no_copy_assign(no_copy_assign&&) noexcept = default;
 		constexpr no_copy_assign& operator=(no_copy_assign&&) noexcept = default;
 	};
+
+	/**
+	 * @brief Type that has its copy constructor and copy assignment operator deleted.
+	 *
+	 * Inherit from this to easily make a type non-copyable.
+	*/
+	struct no_copy : no_copy_construct, no_copy_assign {};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -274,6 +274,20 @@ namespace jc
 	 * Inherit from this to easily make a type non-copyable.
 	*/
 	struct no_copy : no_copy_construct, no_copy_assign {};
+
+	/**
+	 * @brief Type that has its move constructor deleted.
+	 *
+	 * Inherit from this to easily delete the move constructor.
+	*/
+	struct no_move_construct
+	{
+		constexpr no_move_construct() noexcept = default;
+		constexpr no_move_construct(const no_move_construct&) noexcept = default;
+		constexpr no_move_construct& operator=(const no_move_construct&) noexcept = default;
+		constexpr no_move_construct(no_move_construct&&) noexcept = delete;
+		constexpr no_move_construct& operator=(no_move_construct&&) noexcept = default;
+	};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -302,6 +302,13 @@ namespace jc
 		constexpr no_move_assign(no_move_assign&&) noexcept = default;
 		constexpr no_move_assign& operator=(no_move_assign&&) noexcept = delete;
 	};
+
+	/**
+	 * @brief Type that has its move constructor and move assignment operator deleted.
+	 *
+	 * Inherit from this to easily make a type non-moveable.
+	*/
+	struct no_move : no_move_construct, no_move_assign {};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -273,7 +273,14 @@ namespace jc
 	 *
 	 * Inherit from this to easily make a type non-copyable.
 	*/
-	struct no_copy : no_copy_construct, no_copy_assign {};
+	struct no_copy
+	{
+		constexpr no_copy() noexcept = default;
+		constexpr no_copy(const no_copy&) noexcept = delete;
+		constexpr no_copy& operator=(const no_copy&) noexcept = delete;
+		constexpr no_copy(no_copy&&) noexcept = default;
+		constexpr no_copy& operator=(no_copy&&) noexcept = default;
+	};
 
 	/**
 	 * @brief Type that has its move constructor deleted.

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -306,9 +306,16 @@ namespace jc
 	/**
 	 * @brief Type that has its move constructor and move assignment operator deleted.
 	 *
-	 * Inherit from this to easily make a type non-moveable.
+	 * Inherit from this to easily make a type non-movable.
 	*/
-	struct no_move : no_move_construct, no_move_assign {};
+	struct no_move
+	{
+		constexpr no_move() noexcept = default;
+		constexpr no_move(const no_move&) noexcept = default;
+		constexpr no_move& operator=(const no_move&) noexcept = default;
+		constexpr no_move(no_move&&) noexcept = delete;
+		constexpr no_move& operator=(no_move&&) noexcept = delete;
+	};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -238,5 +238,21 @@ namespace jc
 };
 
 
+namespace jc
+{
+	/**
+	 * @brief Type that has its copy constructor deleted.
+	 * 
+	 * Inherit from this to easily delete the copy constructor.
+	*/
+	struct no_copy_construct
+	{
+		constexpr no_copy_construct() noexcept = default;
+		constexpr no_copy_construct(const no_copy_construct&) noexcept = delete;
+		constexpr no_copy_construct& operator=(const no_copy_construct&) noexcept = default;
+		constexpr no_copy_construct(no_copy_construct&&) noexcept = default;
+		constexpr no_copy_construct& operator=(no_copy_construct&&) noexcept = default;
+	};
+}
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -253,6 +253,20 @@ namespace jc
 		constexpr no_copy_construct(no_copy_construct&&) noexcept = default;
 		constexpr no_copy_construct& operator=(no_copy_construct&&) noexcept = default;
 	};
+
+	/**
+	 * @brief Type that has its copy assignment operator deleted.
+	 *
+	 * Inherit from this to easily delete the copy assignment operator.
+	*/
+	struct no_copy_assign
+	{
+		constexpr no_copy_assign() noexcept = default;
+		constexpr no_copy_assign(const no_copy_assign&) noexcept = default;
+		constexpr no_copy_assign& operator=(const no_copy_assign&) noexcept = delete;
+		constexpr no_copy_assign(no_copy_assign&&) noexcept = default;
+		constexpr no_copy_assign& operator=(no_copy_assign&&) noexcept = default;
+	};
 }
 
 #endif

--- a/include/jclib/type.h
+++ b/include/jclib/type.h
@@ -323,6 +323,20 @@ namespace jc
 		constexpr no_move(no_move&&) noexcept = delete;
 		constexpr no_move& operator=(no_move&&) noexcept = delete;
 	};
+
+	/**
+	 * @brief Type that has its move/copy constructors and assigment operators deleted.
+	 *
+	 * Inherit from this to easily make a type non-movable and non-copyable.
+	*/
+	struct no_copy_or_move
+	{
+		constexpr no_copy_or_move() noexcept = default;
+		constexpr no_copy_or_move(const no_copy_or_move&) noexcept = delete;
+		constexpr no_copy_or_move& operator=(const no_copy_or_move&) noexcept = delete;
+		constexpr no_copy_or_move(no_copy_or_move&&) noexcept = delete;
+		constexpr no_copy_or_move& operator=(no_copy_or_move&&) noexcept = delete;
+	};
 }
 
 #endif

--- a/tests/type/no_copy_move.cmake
+++ b/tests/type/no_copy_move.cmake
@@ -1,0 +1,3 @@
+# no_copy_or_move Test Driver
+
+JCLIB_ADD_TEST("type-no_copy_or_move" "${CMAKE_CURRENT_LIST_DIR}/no_copy_or_move.cpp")

--- a/tests/type/no_copy_or_move.cpp
+++ b/tests/type/no_copy_or_move.cpp
@@ -1,0 +1,58 @@
+#include <jclib-test.hpp>
+#include <jclib/type.h>
+
+// Test no_copy_construct
+static_assert(jc::is_default_constructible<jc::no_copy_construct>::value == true, "jc::no_copy_construct should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_construct>::value == false, "jc::no_copy_construct should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_construct>::value == true, "jc::no_copy_construct should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_construct>::value == true, "jc::no_copy_construct should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_construct>::value == true, "jc::no_copy_construct should be move assignable");
+
+// Test no_copy_assign
+static_assert(jc::is_default_constructible<jc::no_copy_assign>::value == true, "jc::no_copy_assign should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_assign>::value == true, "jc::no_copy_assign should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_assign>::value == false, "jc::no_copy_assign should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_assign>::value == true, "jc::no_copy_assign should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_assign>::value == true, "jc::no_copy_assign should be move assignable");
+
+// Test no_copy
+static_assert(jc::is_default_constructible<jc::no_copy>::value == true, "jc::no_copy should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy>::value == false, "jc::no_copy should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy>::value == false, "jc::no_copy should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy>::value == true, "jc::no_copy should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy>::value == true, "jc::no_copy should be move assignable");
+
+// Test no_move_construct
+static_assert(jc::is_default_constructible<jc::no_move_construct>::value == true, "jc::no_move_construct should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move_construct>::value == true, "jc::no_move_construct should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move_construct>::value == true, "jc::no_move_construct should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move_construct>::value == false, "jc::no_move_construct should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move_construct>::value == true, "jc::no_move_construct should be move assignable");
+
+// Test no_move_assign
+static_assert(jc::is_default_constructible<jc::no_move_assign>::value == true, "jc::no_move_assign should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move_assign>::value == true, "jc::no_move_assign should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move_assign>::value == true, "jc::no_move_assign should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true, "jc::no_move_assign should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false, "jc::no_move_assign should not be move assignable");
+
+// Test no_move
+static_assert(jc::is_default_constructible<jc::no_move>::value == true, "jc::no_move should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move>::value == true, "jc::no_move should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move>::value == true, "jc::no_move should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move>::value == false, "jc::no_move should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move>::value == false, "jc::no_move should not be move assignable");
+
+// Test no_copy_or_move
+static_assert(jc::is_default_constructible<jc::no_copy_or_move>::value == true, "jc::no_copy_or_move should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_or_move>::value == false, "jc::no_copy_or_move should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_or_move>::value == false, "jc::no_copy_or_move should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_or_move>::value == false, "jc::no_copy_or_move should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_or_move>::value == false, "jc::no_copy_or_move should not be move assignable");
+
+int main()
+{
+	NEWTEST();
+	// Always passes as this test is all static asserts.
+	PASS();
+};

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -86,6 +86,13 @@ static_assert(jc::is_copy_assignable<jc::no_move_construct>::value == true,			"j
 static_assert(jc::is_move_constructible<jc::no_move_construct>::value == false,		"jc::no_move_construct should not be move constructible");
 static_assert(jc::is_move_assignable<jc::no_move_construct>::value == true,			"jc::no_move_construct should be move assignable");
 
+// Test no_move_assign
+static_assert(jc::is_default_constructible<jc::no_move_assign>::value == true,	"jc::no_move_assign should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false,		"jc::no_move_assign should be move assignable");
+
 int main()
 {
 	NEWTEST();

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -93,6 +93,13 @@ static_assert(jc::is_copy_assignable<jc::no_move_assign>::value == true,		"jc::n
 static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should not be move constructible");
 static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false,		"jc::no_move_assign should be move assignable");
 
+// Test no_move
+static_assert(jc::is_default_constructible<jc::no_move>::value == true,	"jc::no_move should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move>::value == true,	"jc::no_move should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move>::value == true,		"jc::no_move should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move>::value == false,	"jc::no_move should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move>::value == false,		"jc::no_move should be move assignable");
+
 int main()
 {
 	NEWTEST();

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -65,6 +65,14 @@ static_assert(jc::is_copy_assignable<jc::no_copy_construct>::value == true,			"j
 static_assert(jc::is_move_constructible<jc::no_copy_construct>::value == true,		"jc::no_copy_construct should be move constructible");
 static_assert(jc::is_move_assignable<jc::no_copy_construct>::value == true,			"jc::no_copy_construct should be move assignable");
 
+// Test no_copy_assign
+static_assert(jc::is_default_constructible<jc::no_copy_assign>::value == true,	"jc::no_copy_assign should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_assign>::value == false,		"jc::no_copy_assign should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move assignable");
+
+
 int main()
 {
 	NEWTEST();

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -79,6 +79,13 @@ static_assert(jc::is_copy_assignable<jc::no_copy>::value == false,		"jc::no_copy
 static_assert(jc::is_move_constructible<jc::no_copy>::value == true,	"jc::no_copy should be move constructible");
 static_assert(jc::is_move_assignable<jc::no_copy>::value == true,		"jc::no_copy should be move assignable");
 
+// Test no_move_construct
+static_assert(jc::is_default_constructible<jc::no_move_construct>::value == true,	"jc::no_move_construct should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_move_construct>::value == true,		"jc::no_move_construct should be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_move_construct>::value == true,			"jc::no_move_construct should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_move_construct>::value == false,		"jc::no_move_construct should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move_construct>::value == true,			"jc::no_move_construct should be move assignable");
+
 int main()
 {
 	NEWTEST();

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -90,8 +90,8 @@ static_assert(jc::is_move_assignable<jc::no_move_construct>::value == true,			"j
 static_assert(jc::is_default_constructible<jc::no_move_assign>::value == true,	"jc::no_move_assign should be default constructible");
 static_assert(jc::is_copy_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy constructible");
 static_assert(jc::is_copy_assignable<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should not be move constructible");
-static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false,		"jc::no_move_assign should be move assignable");
+static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false,		"jc::no_move_assign should not be move assignable");
 
 // Test no_move
 static_assert(jc::is_default_constructible<jc::no_move>::value == true,	"jc::no_move should be default constructible");
@@ -99,6 +99,13 @@ static_assert(jc::is_copy_constructible<jc::no_move>::value == true,	"jc::no_mov
 static_assert(jc::is_copy_assignable<jc::no_move>::value == true,		"jc::no_move should be copy assignable");
 static_assert(jc::is_move_constructible<jc::no_move>::value == false,	"jc::no_move should not be move constructible");
 static_assert(jc::is_move_assignable<jc::no_move>::value == false,		"jc::no_move should not be move assignable");
+
+// Test no_copy_or_move
+static_assert(jc::is_default_constructible<jc::no_copy_or_move>::value == true,	"jc::no_copy_or_move should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_or_move>::value == false,	"jc::no_copy_or_move should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_or_move>::value == false,		"jc::no_copy_or_move should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_or_move>::value == false,	"jc::no_copy_or_move should not be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_or_move>::value == false,		"jc::no_copy_or_move should not be move assignable");
 
 int main()
 {

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -58,6 +58,12 @@ int subtest_pointer()
 	PASS();
 };
 
+// Test no_copy_construct
+static_assert(jc::is_default_constructible<jc::no_copy_construct>::value == true,	"jc::no_copy_construct should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy_construct>::value == false,		"jc::no_copy_construct should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy_construct>::value == true,			"jc::no_copy_construct should be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy_construct>::value == true,		"jc::no_copy_construct should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy_construct>::value == true,			"jc::no_copy_construct should be move assignable");
 
 int main()
 {

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -98,7 +98,7 @@ static_assert(jc::is_default_constructible<jc::no_move>::value == true,	"jc::no_
 static_assert(jc::is_copy_constructible<jc::no_move>::value == true,	"jc::no_move should be copy constructible");
 static_assert(jc::is_copy_assignable<jc::no_move>::value == true,		"jc::no_move should be copy assignable");
 static_assert(jc::is_move_constructible<jc::no_move>::value == false,	"jc::no_move should not be move constructible");
-static_assert(jc::is_move_assignable<jc::no_move>::value == false,		"jc::no_move should be move assignable");
+static_assert(jc::is_move_assignable<jc::no_move>::value == false,		"jc::no_move should not be move assignable");
 
 int main()
 {

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -58,55 +58,6 @@ int subtest_pointer()
 	PASS();
 };
 
-// Test no_copy_construct
-static_assert(jc::is_default_constructible<jc::no_copy_construct>::value == true,	"jc::no_copy_construct should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_copy_construct>::value == false,		"jc::no_copy_construct should not be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_copy_construct>::value == true,			"jc::no_copy_construct should be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_copy_construct>::value == true,		"jc::no_copy_construct should be move constructible");
-static_assert(jc::is_move_assignable<jc::no_copy_construct>::value == true,			"jc::no_copy_construct should be move assignable");
-
-// Test no_copy_assign
-static_assert(jc::is_default_constructible<jc::no_copy_assign>::value == true,	"jc::no_copy_assign should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_copy_assign>::value == false,		"jc::no_copy_assign should not be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move constructible");
-static_assert(jc::is_move_assignable<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move assignable");
-
-// Test no_copy
-static_assert(jc::is_default_constructible<jc::no_copy>::value == true,	"jc::no_copy should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_copy>::value == false,	"jc::no_copy should not be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_copy>::value == false,		"jc::no_copy should not be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_copy>::value == true,	"jc::no_copy should be move constructible");
-static_assert(jc::is_move_assignable<jc::no_copy>::value == true,		"jc::no_copy should be move assignable");
-
-// Test no_move_construct
-static_assert(jc::is_default_constructible<jc::no_move_construct>::value == true,	"jc::no_move_construct should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_move_construct>::value == true,		"jc::no_move_construct should be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_move_construct>::value == true,			"jc::no_move_construct should be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_move_construct>::value == false,		"jc::no_move_construct should not be move constructible");
-static_assert(jc::is_move_assignable<jc::no_move_construct>::value == true,			"jc::no_move_construct should be move assignable");
-
-// Test no_move_assign
-static_assert(jc::is_default_constructible<jc::no_move_assign>::value == true,	"jc::no_move_assign should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_move_assign>::value == true,		"jc::no_move_assign should be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_move_assign>::value == true,		"jc::no_move_assign should be move constructible");
-static_assert(jc::is_move_assignable<jc::no_move_assign>::value == false,		"jc::no_move_assign should not be move assignable");
-
-// Test no_move
-static_assert(jc::is_default_constructible<jc::no_move>::value == true,	"jc::no_move should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_move>::value == true,	"jc::no_move should be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_move>::value == true,		"jc::no_move should be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_move>::value == false,	"jc::no_move should not be move constructible");
-static_assert(jc::is_move_assignable<jc::no_move>::value == false,		"jc::no_move should not be move assignable");
-
-// Test no_copy_or_move
-static_assert(jc::is_default_constructible<jc::no_copy_or_move>::value == true,	"jc::no_copy_or_move should be default constructible");
-static_assert(jc::is_copy_constructible<jc::no_copy_or_move>::value == false,	"jc::no_copy_or_move should not be copy constructible");
-static_assert(jc::is_copy_assignable<jc::no_copy_or_move>::value == false,		"jc::no_copy_or_move should not be copy assignable");
-static_assert(jc::is_move_constructible<jc::no_copy_or_move>::value == false,	"jc::no_copy_or_move should not be move constructible");
-static_assert(jc::is_move_assignable<jc::no_copy_or_move>::value == false,		"jc::no_copy_or_move should not be move assignable");
-
 int main()
 {
 	NEWTEST();

--- a/tests/type/null.cpp
+++ b/tests/type/null.cpp
@@ -72,6 +72,12 @@ static_assert(jc::is_copy_assignable<jc::no_copy_assign>::value == false,		"jc::
 static_assert(jc::is_move_constructible<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move constructible");
 static_assert(jc::is_move_assignable<jc::no_copy_assign>::value == true,		"jc::no_copy_assign should be move assignable");
 
+// Test no_copy
+static_assert(jc::is_default_constructible<jc::no_copy>::value == true,	"jc::no_copy should be default constructible");
+static_assert(jc::is_copy_constructible<jc::no_copy>::value == false,	"jc::no_copy should not be copy constructible");
+static_assert(jc::is_copy_assignable<jc::no_copy>::value == false,		"jc::no_copy should not be copy assignable");
+static_assert(jc::is_move_constructible<jc::no_copy>::value == true,	"jc::no_copy should be move constructible");
+static_assert(jc::is_move_assignable<jc::no_copy>::value == true,		"jc::no_copy should be move assignable");
 
 int main()
 {


### PR DESCRIPTION
Added a handful of types that can be inherited from to delete copy/move constructors and assignment operators.

I may expand on this down the road but the main thing I wanted and use often enough is the `no_copy_or_move` type.