### PR TITLE
Fix functor bug

### DIFF
--- a/include/jclib/functor.h
+++ b/include/jclib/functor.h
@@ -414,8 +414,11 @@ namespace jc
 			{};
 			functor_impl& operator=(const functor_impl& _other)
 			{
-				this->reset();
-				this->ptr_ = (_other.good())? _other.get()->clone() : nullptr ;
+				if (this != &_other)
+				{
+					this->reset();
+					this->ptr_ = (_other.good()) ? _other.get()->clone() : nullptr;
+				};
 				return *this;
 			};
 
@@ -425,9 +428,11 @@ namespace jc
 			functor_impl& operator=(functor_impl&& _other) noexcept
 			{
 				// Check that these are not owning the same function object (this should never happen, ever)
-				JCLIB_ASSERT(this->get() != _other.get());
-				this->reset();
-				this->ptr_ = _other.extract();
+				if (this != &_other)
+				{
+					this->reset();
+					this->ptr_ = _other.extract();
+				};
 				return *this;
 			};
 


### PR DESCRIPTION
Fixed likely ancient bug with functor that caused an assert to hit on move assignment if both source and dest are null. Added proper behavior